### PR TITLE
FIX: adding ecg channel to eeg for ica ecg cleaning and ecg-related epoching

### DIFF
--- a/meeg_preprocessing/preprocessing.py
+++ b/meeg_preprocessing/preprocessing.py
@@ -215,7 +215,11 @@ def compute_ica(raw, subject, n_components=0.99, picks=None, decim=None,
 
     picks_ = np.array([raw.ch_names.index(k) for k in ica.ch_names])
     if 'eeg' in ica:
-        picks_ = np.append(picks_, pick_types(raw.info, meg=False, ecg=True)[0])
+        if 'ecg' in raw:
+            picks_ = np.append(picks_, 
+                               pick_types(raw.info, meg=False, ecg=True)[0])
+        else:
+            raise ValueError('There is no ECG channel')
     ecg_epochs = create_ecg_epochs(raw, tmin=ecg_tmin, tmax=ecg_tmax,
                                    picks=picks_, reject=reject_)
     n_ecg_epochs_found = len(ecg_epochs.events)

--- a/meeg_preprocessing/preprocessing.py
+++ b/meeg_preprocessing/preprocessing.py
@@ -214,6 +214,8 @@ def compute_ica(raw, subject, n_components=0.99, picks=None, decim=None,
             reject_.pop(ch_type)
 
     picks_ = np.array([raw.ch_names.index(k) for k in ica.ch_names])
+    if 'eeg' in ica:
+        picks_ = np.append(picks_, pick_types(raw.info, meg=False, ecg=True)[0])
     ecg_epochs = create_ecg_epochs(raw, tmin=ecg_tmin, tmax=ecg_tmax,
                                    picks=picks_, reject=reject_)
     n_ecg_epochs_found = len(ecg_epochs.events)


### PR DESCRIPTION
Quick fix for eeg data processing at the epoching step of ecg artefacts by adding the ecg channel (since no artificial ECG channel can be built from eeg, and meg data are not present there).
It does not solve the situation where there is no ecg in raw, but at least raise an error...
